### PR TITLE
Disabled credentials in $http request

### DIFF
--- a/src/angular-spotify.js
+++ b/src/angular-spotify.js
@@ -87,7 +87,8 @@
               method: method ? method : 'GET',
               params: params,
               data: data,
-              headers: headers
+              headers: headers,
+              withCredentials: false
             })
             .success(function (data) {
               deferred.resolve(data);


### PR DESCRIPTION
When using credentials as default for $http object, the library does not work. The credentials should always be disabled for Spotify API requests.