### PR TITLE
Revise deprecated success & error to then & catch

### DIFF
--- a/src/angular-spotify.js
+++ b/src/angular-spotify.js
@@ -90,10 +90,10 @@
               headers: headers,
               withCredentials: false
             })
-            .success(function (data) {
+            .then(function (data) {
               deferred.resolve(data);
             })
-            .error(function (data) {
+            .catch(function (data) {
               deferred.reject(data);
             });
             return deferred.promise;


### PR DESCRIPTION
## Problem
```js
TypeError: $http(...).success is not a function
    at NgSpotify.api (angular-spotify.js:95)
```

## Angular
**Version 1.6 & Up**
[Deprecation Notice]( https://code.angularjs.org/1.5.10/docs/api/ng/service/$http#deprecation-notice
)

> The $http legacy promise methods success and error have been deprecated and will be removed in v1.6.0. Use the standard then method instead.


## Solution
Revise deprecated **success** & **error** to **then** & **catch**